### PR TITLE
Update *ring* entry.

### DIFF
--- a/categories/cryptography.toml
+++ b/categories/cryptography.toml
@@ -6,8 +6,7 @@ related     = ["tls", "compression"]
 [entry.openssl]
 
 [entry.ring]
-crates_io_id = false
-repository_url = "https://github.com/briansmith/ring"
+name = "<i>ring</i>"
 
 [entry.rust-crypto]
 


### PR DESCRIPTION
_ring_ is on crates.io now, so the entry can be simplified. Also,
capitalize the name correctly and add the customary italics.
