### PR TITLE
Add the Gotham web framework

### DIFF
--- a/categories/web-frameworks.toml
+++ b/categories/web-frameworks.toml
@@ -2,6 +2,8 @@ title       = "Web Frameworks"
 description = "Web frameworks in Rust"
 related     = ["http-servers", "ide", "text-editors"]
 
+[entry.gotham]
+
 [entry.conduit]
 
 [entry.iron]


### PR DESCRIPTION
Hoping you'll consider this pull request for your examples repository which adds details of the (Gotham web framework for Rust](https://gotham.rs).

Let me know if there are any rough edges!